### PR TITLE
Validation mode

### DIFF
--- a/src/test/java/com/coveo/FMTTest.java
+++ b/src/test/java/com/coveo/FMTTest.java
@@ -76,6 +76,18 @@ public class FMTTest {
     assertThat(fmt.getFilesFormatted()).hasSize(1);
   }
 
+  @Test(expected = MojoFailureException.class)
+  public void validateOnlyFailsWhenNotFormatted() throws Exception {
+    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("validateonly_notformatted"), FORMAT);
+    fmt.execute();
+  }
+
+  @Test
+  public void validateOnlySucceedsWhenFormatted() throws Exception {
+    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("validateonly_formatted"), FORMAT);
+    fmt.execute();
+  }
+
   public File loadPom(String folderName) {
     return new File("src/test/resources/", folderName);
   }

--- a/src/test/resources/validateonly_formatted/pom.xml
+++ b/src/test/resources/validateonly_formatted/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <configuration>
+                    <validateOnly>true</validateOnly>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/validateonly_formatted/src/main/java/HelloWorld1.java
+++ b/src/test/resources/validateonly_formatted/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/validateonly_notformatted/pom.xml
+++ b/src/test/resources/validateonly_notformatted/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <configuration>
+                    <validateOnly>true</validateOnly>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/validateonly_notformatted/src/main/java/HelloWorld1.java
+++ b/src/test/resources/validateonly_notformatted/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+public static void main(String[] args) {
+System.out.println("Hello World!");
+}
+}


### PR DESCRIPTION
Solves #8.

Additionally, we could improve the message in `logNumberOfFilesFormatted`, it's a bit ambiguous because we don't know if the files were modified or not. Suggestion: "Successfully _processed_ x files, formatted y". If you like the idea, I'll add a commit for that.