### PR TITLE
Add options to display the files that are not compliant when using check goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,60 @@ example:
 </build>
 ```
 
+
+
+### check Options
+
+`displayFiles` default = true. Display the list of the files that are not compliant
+
+`displayLimit` default = 100. Number of files to display that are not compliant`
+
+example to not display the non-compliant files:
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>com.coveo</groupId>
+            <artifactId>fmt-maven-plugin</artifactId>
+            <version>1.10.0</version>
+            <configuration>
+                <displayFiles>false</displayFiles>
+            </configuration>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>check</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+```
+
+example to limit the display up to 10 files
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>com.coveo</groupId>
+            <artifactId>fmt-maven-plugin</artifactId>
+            <version>1.10.0</version>
+            <configuration>
+                <displayLimit>10</displayLimit>
+            </configuration>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>check</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+```
+
 ### Command line
 
 You can also use it on the command line

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>fmt-maven-plugin</artifactId>
-    <version>1.9.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/coveo/AbstractFMT.java
+++ b/src/main/java/com/coveo/AbstractFMT.java
@@ -9,22 +9,21 @@ import com.google.googlejavaformat.java.FormatterException;
 import com.google.googlejavaformat.java.ImportOrderer;
 import com.google.googlejavaformat.java.RemoveUnusedImports;
 import com.google.googlejavaformat.java.RemoveUnusedImports.JavadocOnlyImports;
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugins.annotations.Parameter;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Parameter;
 
 public abstract class AbstractFMT extends AbstractMojo {
-  private Log logger = getLog();
-  private Formatter formatter = new Formatter();
+  protected Log logger = getLog();
+  protected Formatter formatter = new Formatter();
 
   @Parameter(
     defaultValue = "${project.build.sourceDirectory}",
@@ -52,8 +51,8 @@ public abstract class AbstractFMT extends AbstractMojo {
   @Parameter(defaultValue = ".*\\.java", property = "filesNamePattern")
   private String filesNamePattern;
 
-  private List<String> filesFormatted = new ArrayList<String>();
-  private int nonComplyingFiles;
+  protected List<String> filesFormatted = new ArrayList<String>();
+  protected int nonComplyingFiles;
 
   /**
    * execute.
@@ -149,6 +148,7 @@ public abstract class AbstractFMT extends AbstractMojo {
         if (!isValidateOnly()) {
           sink.write(formatted);
         }
+        nonComplyingFile(file);
         nonComplyingFiles += 1;
       }
       filesFormatted.add(file.getAbsolutePath());
@@ -161,6 +161,9 @@ public abstract class AbstractFMT extends AbstractMojo {
       logger.warn("Failed to format file '" + file + "'.", e);
     }
   }
+
+  /** Hook called when the given file is not compliant. */
+  protected void nonComplyingFile(File file) {}
 
   private void handleMissingDirectory(String directoryDisplayName, File directory)
       throws MojoFailureException {
@@ -194,7 +197,11 @@ public abstract class AbstractFMT extends AbstractMojo {
               + nonComplyingFiles
               + " non-complying files, failing build (validateOnly is true)";
       logger.error(message);
+      additionalFailComplying();
       throw new MojoFailureException(message);
     }
   }
+
+  /** Display optional statistics on the files that are not complying */
+  protected void additionalFailComplying() {}
 }

--- a/src/main/java/com/coveo/Check.java
+++ b/src/main/java/com/coveo/Check.java
@@ -2,54 +2,85 @@ package com.coveo;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static java.lang.String.format;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-@Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY)
+/**
+ * Check mojo that will ensure all files are formatted. If some files are not formatted, an
+ * exception is thrown.
+ */
+@Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class Check extends AbstractFMT {
 
+  /** Flag to display or not the files that are not compliant. */
   @Parameter(defaultValue = "true", property = "displayFiles")
   private boolean displayFiles;
 
+  /** Limit the number of non-complying files to display */
   @Parameter(defaultValue = "100", property = "displayLimit")
   private int displayLimit;
 
-  protected List<String> filesNotFormatted = new ArrayList<String>();
+  /** List of unformatted files. */
+  private List<String> filesNotFormatted = new ArrayList<String>();
 
+  /**
+   * Post Execute action. It is called at the end of the execute method. Subclasses can add extra
+   * checks.
+   *
+   * @param filesProcessed the list of processed files by the formatter
+   * @param nonComplyingFiles the number of files that are not compliant
+   * @throws MojoFailureException if there is an exception
+   */
   @Override
-  protected boolean isValidateOnly() {
-    return true;
-  }
-
-  /** Hook called when a file is not compliant. */
-  protected void nonComplyingFile(File file) {
-    if (isValidateOnly()) {
-      filesNotFormatted.add(file.getAbsolutePath());
-    }
-  }
-
-  /** Display some statistics on the files that are not complying */
-  protected void additionalFailComplying() {
-    if (isValidateOnly() && nonComplyingFiles > 0) {
-
+  protected void postExecute(List<String> filesProcessed, int nonComplyingFiles)
+      throws MojoFailureException {
+    if (nonComplyingFiles > 0) {
+      String message = "Found " + nonComplyingFiles + " non-complying files, failing build";
+      getLog().error(message);
       // do not support limit < 1
       displayLimit = max(1, displayLimit);
 
       // Display first displayLimit files not formatted
       if (displayFiles) {
-        if (nonComplyingFiles > displayLimit) {
-          logger.error("Only printing the first " + displayLimit + " non-complying files.");
-        }
         for (String path :
             filesNotFormatted.subList(0, min(displayLimit, filesNotFormatted.size()))) {
-          logger.error("Non complying file: " + path);
+          getLog().error("Non complying file: " + path);
+        }
+
+        if (nonComplyingFiles > displayLimit) {
+          getLog().error(format("... and %d more files.", nonComplyingFiles - displayLimit));
         }
       }
+      throw new MojoFailureException(message);
     }
+  }
+
+  /**
+   * Hook called when the processd file is not compliant with the formatter.
+   *
+   * @param file the file that is not compliant
+   * @param formatted the corresponding formatted of the file.
+   */
+  @Override
+  protected void onNonComplyingFile(final File file, final String formatted) throws IOException {
+    filesNotFormatted.add(file.getAbsolutePath());
+  }
+
+  /**
+   * Provides the name of the label used when a non-formatted file is found.
+   *
+   * @return the label to use in the log
+   */
+  @Override
+  protected String getProcessingLabel() {
+    return "non-complying";
   }
 }

--- a/src/main/java/com/coveo/Check.java
+++ b/src/main/java/com/coveo/Check.java
@@ -1,13 +1,55 @@
 package com.coveo;
 
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY)
 public class Check extends AbstractFMT {
 
+  @Parameter(defaultValue = "true", property = "displayFiles")
+  private boolean displayFiles;
+
+  @Parameter(defaultValue = "100", property = "displayLimit")
+  private int displayLimit;
+
+  protected List<String> filesNotFormatted = new ArrayList<String>();
+
   @Override
   protected boolean isValidateOnly() {
     return true;
+  }
+
+  /** Hook called when a file is not compliant. */
+  protected void nonComplyingFile(File file) {
+    if (isValidateOnly()) {
+      filesNotFormatted.add(file.getAbsolutePath());
+    }
+  }
+
+  /** Display some statistics on the files that are not complying */
+  protected void additionalFailComplying() {
+    if (isValidateOnly() && nonComplyingFiles > 0) {
+
+      // do not support limit < 1
+      displayLimit = max(1, displayLimit);
+
+      // Display first displayLimit files not formatted
+      if (displayFiles) {
+        if (nonComplyingFiles > displayLimit) {
+          logger.error("Only printing the first " + displayLimit + " non-complying files.");
+        }
+        for (String path :
+            filesNotFormatted.subList(0, min(displayLimit, filesNotFormatted.size()))) {
+          logger.error("Non complying file: " + path);
+        }
+      }
+    }
   }
 }

--- a/src/main/java/com/coveo/FMT.java
+++ b/src/main/java/com/coveo/FMT.java
@@ -1,8 +1,12 @@
 package com.coveo;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.CharSink;
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * FMT class.
@@ -10,17 +14,28 @@ import org.apache.maven.plugins.annotations.Parameter;
  * @author guisim
  * @version $Id: $Id
  */
-@Mojo(name = "format", defaultPhase = LifecyclePhase.PROCESS_SOURCES)
+@Mojo(name = "format", defaultPhase = LifecyclePhase.PROCESS_SOURCES, threadSafe = true)
 public class FMT extends AbstractFMT {
 
-  /** @deprecated Use the {@code fmt:check} goal instead. */
-  @Deprecated
-  @Parameter(defaultValue = "false", property = "validateOnly")
-  private boolean validateOnly;
-
+  /**
+   * Hook called when the processd file is not compliant with the formatter.
+   *
+   * @param file the file that is not compliant
+   * @param formatted the corresponding formatted of the file.
+   */
   @Override
-  @SuppressWarnings("deprecation")
-  public boolean isValidateOnly() {
-    return validateOnly;
+  protected void onNonComplyingFile(File file, String formatted) throws IOException {
+    CharSink sink = Files.asCharSink(file, Charsets.UTF_8);
+    sink.write(formatted);
+  }
+
+  /**
+   * Provides the name of the label used when a non-formatted file is found.
+   *
+   * @return the label to use in the log
+   */
+  @Override
+  protected String getProcessingLabel() {
+    return "reformatted";
   }
 }

--- a/src/test/java/com/coveo/FMTTest.java
+++ b/src/test/java/com/coveo/FMTTest.java
@@ -20,7 +20,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("nosource"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesFormatted()).isEmpty();
+    assertThat(fmt.getFilesProcessed()).isEmpty();
   }
 
   @Test
@@ -28,7 +28,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("notestsource"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesFormatted()).hasSize(2);
+    assertThat(fmt.getFilesProcessed()).hasSize(2);
   }
 
   @Test
@@ -36,7 +36,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("onlytestsources"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesFormatted()).hasSize(1);
+    assertThat(fmt.getFilesProcessed()).hasSize(1);
   }
 
   @Test
@@ -44,7 +44,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("simple"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesFormatted()).hasSize(3);
+    assertThat(fmt.getFilesProcessed()).hasSize(3);
   }
 
   @Test
@@ -52,7 +52,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("failonerrorwithsources"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesFormatted()).isNotEmpty();
+    assertThat(fmt.getFilesProcessed()).isNotEmpty();
   }
 
   @Test(expected = MojoFailureException.class)
@@ -66,7 +66,7 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("additionalfolders"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesFormatted()).hasSize(8);
+    assertThat(fmt.getFilesProcessed()).hasSize(8);
   }
 
   @Test
@@ -74,31 +74,32 @@ public class FMTTest {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("onlyavajsources"), FORMAT);
     fmt.execute();
 
-    assertThat(fmt.getFilesFormatted()).hasSize(1);
+    assertThat(fmt.getFilesProcessed()).hasSize(1);
   }
 
   @Test(expected = MojoFailureException.class)
   public void validateOnlyFailsWhenNotFormatted() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("validateonly_notformatted"), FORMAT);
-    fmt.execute();
+    Check check =
+        (Check) mojoRule.lookupConfiguredMojo(loadPom("validateonly_notformatted"), CHECK);
+    check.execute();
   }
 
   @Test
   public void validateOnlySucceedsWhenFormatted() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("validateonly_formatted"), FORMAT);
-    fmt.execute();
+    Check check = (Check) mojoRule.lookupConfiguredMojo(loadPom("validateonly_formatted"), CHECK);
+    check.execute();
   }
 
   @Test(expected = MojoFailureException.class)
   public void withUnusedImports() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("importunused"), FORMAT);
-    fmt.execute();
+    Check check = (Check) mojoRule.lookupConfiguredMojo(loadPom("importunused"), CHECK);
+    check.execute();
   }
 
   @Test(expected = MojoFailureException.class)
   public void withUnsortedImports() throws Exception {
-    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("importunsorted"), FORMAT);
-    fmt.execute();
+    Check check = (Check) mojoRule.lookupConfiguredMojo(loadPom("importunsorted"), CHECK);
+    check.execute();
   }
 
   @Test

--- a/src/test/resources/importclean/pom.xml
+++ b/src/test/resources/importclean/pom.xml
@@ -24,13 +24,10 @@
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>1.0.0</version>
-                <configuration>
-                    <validateOnly>true</validateOnly>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>format</goal>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/test/resources/importunsorted/pom.xml
+++ b/src/test/resources/importunsorted/pom.xml
@@ -24,13 +24,10 @@
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>1.0.0</version>
-                <configuration>
-                    <validateOnly>true</validateOnly>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>format</goal>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/test/resources/importunused/pom.xml
+++ b/src/test/resources/importunused/pom.xml
@@ -24,13 +24,10 @@
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>1.0.0</version>
-                <configuration>
-                    <validateOnly>true</validateOnly>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>format</goal>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/test/resources/validateonly_formatted/pom.xml
+++ b/src/test/resources/validateonly_formatted/pom.xml
@@ -24,13 +24,10 @@
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>1.0.0</version>
-                <configuration>
-                    <validateOnly>true</validateOnly>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>format</goal>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/test/resources/validateonly_notformatted/pom.xml
+++ b/src/test/resources/validateonly_notformatted/pom.xml
@@ -24,13 +24,10 @@
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>1.0.0</version>
-                <configuration>
-                    <validateOnly>true</validateOnly>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>format</goal>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
### What this PR do
Today when using the check goal I don't know the files that are not compliant.

This PR introduce:
- display files that are not compliant will be listed (it can be turned off)
- The number of files are limited to 100 by default (configuration parameter)

### Documentation
I've updated README.md file with example