### PR TITLE
Help message to run fmt:format when build fails.

### DIFF
--- a/src/main/java/com/coveo/Check.java
+++ b/src/main/java/com/coveo/Check.java
@@ -45,6 +45,7 @@ public class Check extends AbstractFMT {
     if (nonComplyingFiles > 0) {
       String message = "Found " + nonComplyingFiles + " non-complying files, failing build";
       getLog().error(message);
+      getLog().error("To fix formatting errors, run \"mvn fmt:format\"");
       // do not support limit < 1
       displayLimit = max(1, displayLimit);
 


### PR DESCRIPTION
On large teams with infrequent contributors, a *help* message to run the formatter would be nice.
Fixes #18