### PR TITLE
Optional support for AOSP mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ If you prefer, you can only check formatting at build time using the `check` goa
 
 `filesNamePattern` represents the pattern that filters files to format. The defaults value is set to `.*\.java`.
 
+`style` sets the formatter style to be _google_ or _aosp_. By default this is 'google'. Projects using Android conventions may prefer `aosp`.
+
 example:
 ```xml
 <build>
@@ -88,6 +90,7 @@ example:
                     <param>some/dir</param>
                     <param>some/other/dir</param>
                 </additionalSourceDirectories>
+                <style>google</style>
             </configuration>
             <executions>
                 <execution>
@@ -108,6 +111,8 @@ example:
 `displayFiles` default = true. Display the list of the files that are not compliant
 
 `displayLimit` default = 100. Number of files to display that are not compliant`
+
+`style` sets the formatter style to be _google_ or _aosp_. By default this is 'google'. Projects using Android conventions may prefer `aosp`.
 
 example to not display the non-compliant files:
 ```xml

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>fmt-maven-plugin</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/test/java/com/coveo/FMTTest.java
+++ b/src/test/java/com/coveo/FMTTest.java
@@ -3,7 +3,9 @@ package com.coveo;
 import static com.google.common.truth.Truth.*;
 
 import java.io.File;
+import java.util.List;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.testing.MojoRule;
 import org.junit.Rule;
@@ -53,6 +55,12 @@ public class FMTTest {
     fmt.execute();
 
     assertThat(fmt.getFilesProcessed()).hasSize(3);
+
+    /* Let's make sure we formatted with AOSP using 4 spaces */
+    List<String> lines =
+        IOUtils.readLines(
+            getClass().getResourceAsStream("/simple_aosp/src/main/java/HelloWorld1.java"));
+    assertThat(lines.get(3)).startsWith("    ");
   }
 
   @Test
@@ -61,6 +69,12 @@ public class FMTTest {
     fmt.execute();
 
     assertThat(fmt.getFilesProcessed()).hasSize(3);
+
+    /* Let's make sure we formatted with Google using 2 spaces */
+    List<String> lines =
+        IOUtils.readLines(
+            getClass().getResourceAsStream("/simple_google/src/main/java/HelloWorld1.java"));
+    assertThat(lines.get(3)).startsWith("  ");
   }
 
   @Test
@@ -142,7 +156,7 @@ public class FMTTest {
     check.execute();
   }
 
-  public File loadPom(String folderName) {
+  private File loadPom(String folderName) {
     return new File("src/test/resources/", folderName);
   }
 }

--- a/src/test/java/com/coveo/FMTTest.java
+++ b/src/test/java/com/coveo/FMTTest.java
@@ -60,7 +60,7 @@ public class FMTTest {
     List<String> lines =
         IOUtils.readLines(
             getClass().getResourceAsStream("/simple_aosp/src/main/java/HelloWorld1.java"));
-    assertThat(lines.get(3)).startsWith("    ");
+    assertThat(lines.get(3)).startsWith("    public");
   }
 
   @Test
@@ -74,7 +74,7 @@ public class FMTTest {
     List<String> lines =
         IOUtils.readLines(
             getClass().getResourceAsStream("/simple_google/src/main/java/HelloWorld1.java"));
-    assertThat(lines.get(3)).startsWith("  ");
+    assertThat(lines.get(3)).startsWith("  public");
   }
 
   @Test

--- a/src/test/java/com/coveo/FMTTest.java
+++ b/src/test/java/com/coveo/FMTTest.java
@@ -48,6 +48,22 @@ public class FMTTest {
   }
 
   @Test
+  public void withAllTypesOfSourcesWithAospStyleSpecified() throws Exception {
+    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("simple_aosp"), FORMAT);
+    fmt.execute();
+
+    assertThat(fmt.getFilesProcessed()).hasSize(3);
+  }
+
+  @Test
+  public void withAllTypesOfSourcesWithGoogleStyleSpecified() throws Exception {
+    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("simple_google"), FORMAT);
+    fmt.execute();
+
+    assertThat(fmt.getFilesProcessed()).hasSize(3);
+  }
+
+  @Test
   public void failOnUnknownFolderDoesNotFailWhenEverythingIsThere() throws Exception {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("failonerrorwithsources"), FORMAT);
     fmt.execute();
@@ -58,6 +74,12 @@ public class FMTTest {
   @Test(expected = MojoFailureException.class)
   public void failOnUnknownFolderFailsWhenAFolderIsMissing() throws Exception {
     FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("failonerrormissingsources"), FORMAT);
+    fmt.execute();
+  }
+
+  @Test(expected = MojoFailureException.class)
+  public void failOnUnknownStyle() throws Exception {
+    FMT fmt = (FMT) mojoRule.lookupConfiguredMojo(loadPom("failonunknownstyle"), FORMAT);
     fmt.execute();
   }
 

--- a/src/test/resources/failonunknownstyle/pom.xml
+++ b/src/test/resources/failonunknownstyle/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <configuration>
+                    <style>nope</style>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/failonunknownstyle/src/main/java/HelloWorld1.java
+++ b/src/test/resources/failonunknownstyle/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/failonunknownstyle/src/main/java/HelloWorld2.java
+++ b/src/test/resources/failonunknownstyle/src/main/java/HelloWorld2.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/failonunknownstyle/src/test/java/HelloWorldTest.java
+++ b/src/test/resources/failonunknownstyle/src/test/java/HelloWorldTest.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorldTest {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/simple_aosp/pom.xml
+++ b/src/test/resources/simple_aosp/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <configuration>
+                    <style>aosp</style>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/simple_aosp/src/main/java/HelloWorld1.java
+++ b/src/test/resources/simple_aosp/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+    }
+}

--- a/src/test/resources/simple_aosp/src/main/java/HelloWorld2.java
+++ b/src/test/resources/simple_aosp/src/main/java/HelloWorld2.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+    }
+}

--- a/src/test/resources/simple_aosp/src/test/java/HelloWorldTest.java
+++ b/src/test/resources/simple_aosp/src/test/java/HelloWorldTest.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorldTest {
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+    }
+}

--- a/src/test/resources/simple_google/pom.xml
+++ b/src/test/resources/simple_google/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <configuration>
+                    <style>google</style>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/simple_google/src/main/java/HelloWorld1.java
+++ b/src/test/resources/simple_google/src/main/java/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/simple_google/src/main/java/HelloWorld2.java
+++ b/src/test/resources/simple_google/src/main/java/HelloWorld2.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/src/test/resources/simple_google/src/test/java/HelloWorldTest.java
+++ b/src/test/resources/simple_google/src/test/java/HelloWorldTest.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorldTest {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}


### PR DESCRIPTION
Exposes the Google Java Formatter's Android Open Source Project mode as a configuration option to the formatter.

- Adds new `style` option which is `google` by default, but can be set to `aosp`
- `AbstractFMT.formatter` is now lazily created and configured with style settings
- Unit tests for
  - unknown style configuration is rejected
  - `google` style is supported
  - `aosp` style is supported