### PR TITLE
Feature/parallelize file parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
             <organization>Coveo</organization>
             <organizationUrl>http://github.com/coveo</organizationUrl>
         </developer>
+        <developer>
+            <name>Andy Emond</name>
+            <organization>Coveo</organization>
+            <organizationUrl>http://github.com/coveo</organizationUrl>
+        </developer>
     </developers>
 
     <scm>
@@ -147,6 +152,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/coveo/AbstractFMT.java
+++ b/src/main/java/com/coveo/AbstractFMT.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -128,7 +129,8 @@ public abstract class AbstractFMT extends AbstractMojo {
 
     try (Stream<Path> paths = Files.walk(Paths.get(directory.getPath()))) {
       paths
-          .parallel()
+          .collect(Collectors.toList())
+          .parallelStream()
           .filter(Files::isRegularFile)
           .map(Path::toFile)
           .filter((file) -> getFileFilter().accept(file))


### PR DESCRIPTION
Parallelize the file formatting, shows some interesting performance improvement on my setup:

|Benchmark|                   Mode|  Cnt|  Score|   Error|  Units|
|-----------|-----------------|-----|-------|-------|-------|
|BenchmarkRunner.newFormatSourceFilesInDirectory  |thrpt|   20|  0,626| ± 0,093|  ops/s
|BenchmarkRunner.oldFormatSourceFilesInDirectory  |thrpt|   20|  0,440| ± 0,084|  ops/s
|BenchmarkRunner.newFormatSourceFilesInDirectory  |avgt|   20|  1,489| ± 0,206|   s/op
|BenchmarkRunner.oldFormatSourceFilesInDirectory   |avgt|   20|  3,321| ± 0,545|   s/op

These numbers were optained using jmh, on a medium sized projet that I own.
