### PR TITLE
Match file pattern against path

### DIFF
--- a/src/main/java/com/coveo/AbstractFMT.java
+++ b/src/main/java/com/coveo/AbstractFMT.java
@@ -171,7 +171,7 @@ public abstract class AbstractFMT extends AbstractMojo {
     return new FileFilter() {
       @Override
       public boolean accept(File pathname) {
-        return pathname.isDirectory() || pathname.getName().matches(filesNamePattern);
+        return pathname.isDirectory() || pathname.getPath().matches(filesNamePattern);
       }
     };
   }

--- a/src/main/java/com/coveo/AbstractFMT.java
+++ b/src/main/java/com/coveo/AbstractFMT.java
@@ -133,12 +133,13 @@ public abstract class AbstractFMT extends AbstractMojo {
     }
 
     try (Stream<Path> paths = Files.walk(Paths.get(directory.getPath()))) {
+      FileFilter fileFilter = getFileFilter();
       paths
           .collect(Collectors.toList())
           .parallelStream()
           .filter(Files::isRegularFile)
           .map(Path::toFile)
-          .filter((file) -> getFileFilter().accept(file))
+          .filter((file) -> fileFilter.accept(file))
           .forEach(file -> formatSourceFile(file, formatter));
     } catch (IOException exception) {
       throw new MojoFailureException(exception.getMessage());

--- a/src/test/java/com/coveo/FMTTest.java
+++ b/src/test/java/com/coveo/FMTTest.java
@@ -156,6 +156,13 @@ public class FMTTest {
     check.execute();
   }
 
+  @Test
+  public void checkSucceedsWhenNotFormattedButIgnored() throws Exception {
+    Check check =
+        (Check) mojoRule.lookupConfiguredMojo(loadPom("check_notformatted_ignored"), CHECK);
+    check.execute();
+  }
+
   private File loadPom(String folderName) {
     return new File("src/test/resources/", folderName);
   }

--- a/src/test/resources/check_notformatted_ignored/pom.xml
+++ b/src/test/resources/check_notformatted_ignored/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <configuration>
+                    <filesNamePattern>^((?!\Wignored\W).)*\.java$</filesNamePattern>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/check_notformatted_ignored/src/main/java/ignored/HelloWorld1Unformatted.java
+++ b/src/test/resources/check_notformatted_ignored/src/main/java/ignored/HelloWorld1Unformatted.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+public static void main(String[] args) {
+System.out.println("Hello World!");
+}
+}

--- a/src/test/resources/check_notformatted_ignored/src/main/java/notignored/HelloWorld1.java
+++ b/src/test/resources/check_notformatted_ignored/src/main/java/notignored/HelloWorld1.java
@@ -1,0 +1,7 @@
+package notestsource.src.main.java;
+
+public class HelloWorld1 {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}


### PR DESCRIPTION
I am trying to exclude some files (generated sources) from the format check.
They can be identified by their location inside the build directory.

Unfortunately, the `filesNamePattern` is only matched against the file name and not the path.

This PR changes that by matching against the file path instead.

Of course, we might want to either
1. rename the parameter to something like `filesPathPattern` or
2. add another parameter to do this

What do you think would be the best way of addressing this?