### PR TITLE
Auto-skip plugin execution on pom projects

### DIFF
--- a/src/main/java/com/coveo/AbstractFMT.java
+++ b/src/main/java/com/coveo/AbstractFMT.java
@@ -38,6 +38,12 @@ public abstract class AbstractFMT extends AbstractMojo {
   )
   private File testSourceDirectory;
 
+  @Parameter(
+    defaultValue = "${project.packaging}",
+    required = true
+  )
+  private String packaging;
+  
   @Parameter(property = "additionalSourceDirectories")
   private File[] additionalSourceDirectories;
 
@@ -70,6 +76,10 @@ public abstract class AbstractFMT extends AbstractMojo {
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (skip) {
       getLog().info("Skipping format check");
+      return;
+    }
+    if ("pom".equals(packaging)) {
+      getLog().info("Skipping format check: project uses 'pom' packaging");
       return;
     }
     if (skipSortingImports) {


### PR DESCRIPTION
Addresses #41 by injecting project's packaging property and checking its value at the start of the `execute()` method.