### PR TITLE
docs: correct version in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To have your sources automatically formatted on each build, add to your pom.xml:
             <plugin>
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.8.0</version>
+                <version>2.8</version>
                 <executions>
                     <execution>
                         <goals>
@@ -46,7 +46,7 @@ If you prefer, you can only check formatting at build time using the `check` goa
             <plugin>
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.8.0</version>
+                <version>2.8</version>
                 <executions>
                     <execution>
                         <goals>
@@ -84,7 +84,7 @@ example:
         <plugin>
             <groupId>com.coveo</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.8.0</version>
+            <version>2.8</version>
             <configuration>
                 <sourceDirectory>some/source/directory</sourceDirectory>
                 <testSourceDirectory>some/test/directory</testSourceDirectory>
@@ -127,7 +127,7 @@ example to not display the non-compliant files:
         <plugin>
             <groupId>com.coveo</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.8.0</version>
+            <version>2.8</version>
             <configuration>
                 <displayFiles>false</displayFiles>
             </configuration>
@@ -150,7 +150,7 @@ example to limit the display up to 10 files
         <plugin>
             <groupId>com.coveo</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.8.0</version>
+            <version>2.8</version>
             <configuration>
                 <displayLimit>10</displayLimit>
             </configuration>


### PR DESCRIPTION
There is no version 2.8.0 only 2.8